### PR TITLE
Added "goodbot" and "badbot" to recognition

### DIFF
--- a/public/scripts/script.js
+++ b/public/scripts/script.js
@@ -38,11 +38,11 @@ module.exports = {
                 var comment = key.body.substring(0,8).toLowerCase();
                 
                 
-                if(comment == "good bot") {
+                if(comment == "good bot" || "goodbot") {
                     console.log("Found comment '" + key.body + "'");
                     _storeVote(key, "good");
                 }
-                else if(comment == "bad bot") {
+                else if(comment == "bad bot" || "badbot") {
                     console.log("Found comment '" + key.body + "'");
                     _storeVote(key, "bad");
                 }


### PR DESCRIPTION
It's fairly common for Reddit bots to use trigger words without spaces, so they don't get confused with normal conversation. Many people are trying to vote with this bot and they're not being recognized because they're typing "GoodBot" or "BadBot", so this fixes that.